### PR TITLE
feat(release): add release infrastructure for v1.0.0 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,9 +18,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -X github.com/DinethDilhara/glo/cmd.version={{.Version}}
+      - -X github.com/DinethDilhara/glo/cmd.commit={{.Commit}}
+      - -X github.com/DinethDilhara/glo/cmd.date={{.Date}}
 
 archives:
   - id: default
@@ -70,11 +70,16 @@ release:
   prerelease: auto
   mode: replace
   header: |
-    ## 🚀 What's New in {{ .Tag }}
+    ## Changes in {{.Tag}}
 
-    Welcome to the latest release of **glo** - your powerful Git history explorer!
+    This release includes improvements and bug fixes for the glo CLI tool.
   footer: |
-    ## 📦 Installation
+    ## Installation
+
+    ### Using Homebrew
+    ```bash
+    brew install dinethdhilhara/tap/glo
+    ```
 
     ### Using curl (Linux/macOS)
     ```bash
@@ -86,8 +91,6 @@ release:
     Invoke-WebRequest -Uri "https://github.com/DinethDilhara/glo/releases/download/{{ .Tag }}/glo_{{ .Version }}_Windows_x86_64.zip" -OutFile "glo.zip"
     Expand-Archive glo.zip
     ```
-
-    ---
 
     **Full Changelog**: https://github.com/DinethDilhara/glo/compare/{{ .PreviousTag }}...{{ .Tag }}
 
@@ -101,4 +104,4 @@ brews:
       name: homebrew-tap
     folder: Formula
     test: |
-      system "#{bin}/glo --help"
+      system "#{bin}/glo --version"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+.PHONY: build test clean install release-local release-snapshot help
+
+# Build variables
+BINARY_NAME=glo
+VERSION?=$(shell git describe --tags --always --dirty)
+COMMIT?=$(shell git rev-parse --short HEAD)
+DATE?=$(shell date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+# Go variables
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+
+# LDFLAGS
+LDFLAGS=-ldflags "-s -w -X github.com/DinethDilhara/glo/cmd.version=$(VERSION) -X github.com/DinethDilhara/glo/cmd.commit=$(COMMIT) -X 'github.com/DinethDilhara/glo/cmd.date=$(DATE)'"
+
+## help: Display this help message
+help:
+	@echo "Available commands:"
+	@sed -n 's/^##//p' $(MAKEFILE_LIST) | column -t -s ':' | sed -e 's/^/ /'
+
+## build: Build the binary
+build:
+	$(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME) .
+
+## test: Run tests
+test:
+	$(GOTEST) -v ./...
+
+## clean: Clean build artifacts
+clean:
+	$(GOCLEAN)
+	rm -f $(BINARY_NAME)
+
+## install: Install the binary to /usr/local/bin
+install: build
+	sudo mv $(BINARY_NAME) /usr/local/bin/
+
+## release-local: Build release locally (without publishing)
+release-local:
+	goreleaser release --clean --skip=publish
+
+## release-snapshot: Build snapshot release
+release-snapshot:
+	goreleaser release --snapshot --clean
+
+## deps: Download dependencies
+deps:
+	$(GOMOD) download
+	$(GOMOD) tidy
+
+## lint: Run golangci-lint
+lint:
+	golangci-lint run
+
+## check: Run tests and linting
+check: test lint
+
+## version: Show current version
+version:
+	@echo "Version: $(VERSION)"
+	@echo "Commit: $(COMMIT)"
+	@echo "Date: $(DATE)"

--- a/README.md
+++ b/README.md
@@ -48,13 +48,24 @@ Download the latest binary from [GitHub Releases](https://github.com/DinethDilha
 | **macOS**   | Apple Silicon | [glo_Darwin_arm64.tar.gz](https://github.com/DinethDilhara/glo/releases/latest/download/glo_Darwin_arm64.tar.gz)   |
 | **Windows** | x86_64        | [glo_Windows_x86_64.zip](https://github.com/DinethDilhara/glo/releases/latest/download/glo_Windows_x86_64.zip)     |
 
+## Installation
+
+### Homebrew (Recommended)
+
+```bash
+brew install dinethdhilhara/tap/glo
+```
+
+### Download Binary
+
+Download the latest binary from [GitHub Releases](https://github.com/DinethDilhara/glo/releases).
+
 ### From Source
 
 ```bash
 git clone https://github.com/DinethDilhara/glo.git
 cd glo
 go build -o glo .
-sudo mv glo /usr/local/bin/  # Optional: add to PATH
 ```
 
 ### Homebrew (Coming Soon)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ Examples:
   glo log --since="2024-01-01"         # Show commits since date
   glo log --format=json                # Export as JSON
   glo log --format=markdown            # Export as Markdown`,
+	Version: version,
 }
 
 
@@ -60,5 +61,5 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	
 	rootCmd.PersistentFlags().StringP("format", "f", "color", "Output format: color, json, markdown")
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
+	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Release script for glo
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' 
+
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+if [ $# -eq 0 ]; then
+    print_error "Please provide a version number (e.g., v1.0.0)"
+    exit 1
+fi
+
+VERSION=$1
+
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    print_error "Version must be in format vX.Y.Z (e.g., v1.0.0)"
+    exit 1
+fi
+
+print_status "Starting release process for $VERSION"
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ $CURRENT_BRANCH != "main" && $CURRENT_BRANCH != "release/"* ]]; then
+    print_warning "You're not on main or a release branch. Current branch: $CURRENT_BRANCH"
+    read -p "Continue anyway? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+if [[ -n $(git status --porcelain) ]]; then
+    print_error "Working directory is not clean. Please commit or stash changes."
+    exit 1
+fi
+
+print_status "Running tests..."
+if ! go test ./...; then
+    print_error "Tests failed. Please fix before releasing."
+    exit 1
+fi
+
+print_status "Building application..."
+if ! go build -o glo .; then
+    print_error "Build failed."
+    exit 1
+fi
+
+print_status "Testing built binary..."
+if ! ./glo --version; then
+    print_error "Built binary doesn't work."
+    exit 1
+fi
+
+print_status "Creating and pushing tag $VERSION..."
+git tag -a $VERSION -m "Release $VERSION"
+git push origin $VERSION
+
+print_status "Release $VERSION has been created and pushed!"
+print_status "GitHub Actions will now build and publish the release."
+print_status "Check the progress at: https://github.com/DinethDilhara/glo/actions"
+
+print_warning "Next steps:"
+echo "1. Wait for GitHub Actions to complete the release"
+echo "2. Verify the release at: https://github.com/DinethDilhara/glo/releases"
+echo "3. Test Homebrew installation: brew install dinethdhilhara/tap/glo"


### PR DESCRIPTION
## Release v1.0.0

This PR prepares the first official release of glo with complete distribution infrastructure.

### Changes
- Add GitHub Actions workflow for automated releases
-  Configure GoReleaser with Homebrew tap support  
-  Add Makefile with build automation and release targets
-  Add version flag support (`glo -v`, `glo --version`)
-  Create release script for version management

### Installation Methods After Release
- Homebrew: `brew install dinethdhilhara/tap/glo`
- Direct download from GitHub Releases
- Build from source
